### PR TITLE
Send async task after commit (fixes #39)

### DIFF
--- a/enhydris_autoprocess/apps.py
+++ b/enhydris_autoprocess/apps.py
@@ -1,7 +1,8 @@
 from django.apps import AppConfig
+from django.db import transaction
 from django.db.models.signals import post_save
 
-from . import tasks
+from .tasks import execute_auto_process
 
 
 def enqueue_auto_process(sender, *, instance, **kwargs):
@@ -11,7 +12,7 @@ def enqueue_auto_process(sender, *, instance, **kwargs):
         if auto_process.as_specific_instance.source_timeseries == instance
     ]
     for auto_process in auto_processes:
-        tasks.execute_auto_process.delay(auto_process.id)
+        transaction.on_commit(lambda: execute_auto_process.delay(auto_process.id))
 
 
 class AutoprocessConfig(AppConfig):

--- a/enhydris_autoprocess/models.py
+++ b/enhydris_autoprocess/models.py
@@ -61,9 +61,7 @@ class AutoProcess(models.Model):
 
     def save(self, *args, **kwargs):
         result = super().save(*args, **kwargs)
-        transaction.on_commit(
-            lambda: tasks.execute_auto_process.apply_async(args=[self.id])
-        )
+        transaction.on_commit(lambda: tasks.execute_auto_process.delay(self.id))
         return result
 
     @property

--- a/enhydris_autoprocess/tests/test_apps.py
+++ b/enhydris_autoprocess/tests/test_apps.py
@@ -1,31 +1,42 @@
 from unittest import mock
 
-from django.test import TestCase
+from django.db import transaction
+from django.test import TransactionTestCase
 
 from model_mommy import mommy
 
 from enhydris.models import Station, Timeseries
-from enhydris_autoprocess import tasks
 from enhydris_autoprocess.models import Checks
 
 
-class EnqueueAutoProcessTestCase(TestCase):
+class EnqueueAutoProcessTestCase(TransactionTestCase):
+    # Setting available_apps activates TRUNCATE ... CASCADE, which is necessary because
+    # enhydris.TimeseriesRecord is unmanaged, TransactionTestCase doesn't attempt to
+    # truncate it, and PostgreSQL complains it can't truncate enhydris_timeseries
+    # without truncating enhydris_timeseriesrecord at the same time.
+    available_apps = ["enhydris_autoprocess"]
+
     def setUp(self):
-        self.original_execute_auto_process = tasks.execute_auto_process
-        tasks.execute_auto_process = mock.MagicMock()
-
-    def tearDown(self):
-        tasks.execute_auto_process = self.original_execute_auto_process
-
-    def test_enqueues_auto_process(self):
-        station = mommy.make(Station)
-        auto_process = mommy.make(
+        self.station = mommy.make(Station)
+        self.auto_process = mommy.make(
             Checks,
-            timeseries_group__gentity=station,
-            target_timeseries_group__gentity=station,
+            timeseries_group__gentity=self.station,
+            target_timeseries_group__gentity=self.station,
         )
-        timeseries = mommy.make(
-            Timeseries, timeseries_group=auto_process.timeseries_group
+        self.timeseries = mommy.make(
+            Timeseries,
+            timeseries_group=self.auto_process.timeseries_group,
+            type=Timeseries.RAW,
         )
-        timeseries.save()
-        tasks.execute_auto_process.delay.assert_any_call(auto_process.id)
+
+    @mock.patch("enhydris_autoprocess.apps.execute_auto_process")
+    def test_enqueues_auto_process(self, m):
+        with transaction.atomic():
+            self.timeseries.save()
+        m.delay.assert_any_call(self.auto_process.id)
+
+    @mock.patch("enhydris_autoprocess.apps.execute_auto_process")
+    def test_auto_process_is_not_triggered_before_commit(self, m):
+        with transaction.atomic():
+            self.timeseries.save()
+            m.delay.assert_not_called()

--- a/enhydris_autoprocess/tests/test_models.py
+++ b/enhydris_autoprocess/tests/test_models.py
@@ -71,13 +71,13 @@ class AutoProcessSaveTestCase(TransactionTestCase):
         with transaction.atomic():
             auto_process = mommy.make(Checks, timeseries_group=self.timeseries_group)
             auto_process.save()
-        tasks.execute_auto_process.apply_async.assert_any_call(args=[auto_process.id])
+        tasks.execute_auto_process.delay.assert_any_call(auto_process.id)
 
     def test_auto_process_is_not_triggered_before_commit(self):
         with transaction.atomic():
             auto_process = mommy.make(Checks, timeseries_group=self.timeseries_group)
             auto_process.save()
-            tasks.execute_auto_process.apply_async.assert_not_called()
+            tasks.execute_auto_process.delay.assert_not_called()
 
 
 class AutoProcessExecuteTestCase(TestCase):


### PR DESCRIPTION
This also changes apply_async() to delay(); apply_async() isn't needed
since its extra arguments aren't being used.