### PR TITLE
Do not constrain pandas version (fixes #65)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,3 @@
 celery>=4,<5
 haggregate>=2,<3
-# Pandas is installed indirectly through haggregate (on which Enhydris also has
-# a dependency. However, using pandas>=1.1 causes some tests to fail, so for the
-# time being we keep it at <1.1.
-pandas<1.1
 rocc>=1,<3


### PR DESCRIPTION
This commit removes a constraint on pandas version that had been placed
on 18d4dc0829 (2020-08-26), apparently because some tests were failing
in recent pandas version. This no longer seems to be the case.